### PR TITLE
Update BeoidcController.php

### DIFF
--- a/Classes/Controller/BeoidcController.php
+++ b/Classes/Controller/BeoidcController.php
@@ -197,7 +197,7 @@ class BeoidcController extends ActionController
             return 0;
         }
     }
-
+    private string $oidc_object;
     /**
      * @param $postArray
      */


### PR DESCRIPTION
 #1476107295 TYPO3\CMS\Core\Error\Exception
PHP Runtime Deprecation Notice: Creation of dynamic property Miniorange\KeycloakSSO\Controller\BeoidcController::$oidc_object is deprecated in /var/www/html/vendor/miniorange/keycloak_sso/Classes/Controller/BeoidcController.php line 208

Fixed deprecated dynamic property creation in BeoidcController for PHP 8.2 compatibility.  
Added the $oidc_object property explicitly to the class to avoid runtime deprecation warnings.