### PR TITLE
Fix User Info Endpoint URL in docs

### DIFF
--- a/Documentation/Configuration.rst
+++ b/Documentation/Configuration.rst
@@ -32,7 +32,7 @@ Extension Configurations
 	- Scope : openid profile email
 	- Authorization Endpoint : <Keycloak base URL>/realms/{realm-name}/protocol/openid-connect/auth
 	- Token Endpoint : <Keycloak base URL>/realms/{realm-name}/protocol/openid-connect/token
-	- User Info Endpoint : <Keycloak base URL>/realms/{realm-name}/protocol/openid-connect
+	- User Info Endpoint : <Keycloak base URL>/realms/{realm-name}/protocol/openid-connect/userinfo
 	- Set client credentials in : Header/Body
 
 .. figure:: Images/configurations.png


### PR DESCRIPTION
The User Info Endpoint URL was missing the last segment in the documentation.

Without this the test connection function returns an error, when using OAuth as application type in the OpenID Connect Client configuration on TYPO3 side.